### PR TITLE
longing-eel: Enable adding to db & clearing db

### DIFF
--- a/.glitch-assets
+++ b/.glitch-assets
@@ -1,6 +1,3 @@
 {"name":"drag-in-files.svg","date":"2016-10-22T16:17:49.954Z","url":"https://cdn.hyperdev.com/drag-in-files.svg","type":"image/svg","size":7646,"imageWidth":276,"imageHeight":276,"thumbnail":"https://cdn.hyperdev.com/drag-in-files.svg","thumbnailWidth":276,"thumbnailHeight":276,"dominantColor":"rgb(102, 153, 205)","uuid":"adSBq97hhhpFNUna"}
 {"name":"click-me.svg","date":"2016-10-23T16:17:49.954Z","url":"https://cdn.hyperdev.com/click-me.svg","type":"image/svg","size":7116,"imageWidth":276,"imageHeight":276,"thumbnail":"https://cdn.hyperdev.com/click-me.svg","thumbnailWidth":276,"thumbnailHeight":276,"dominantColor":"rgb(243, 185, 186)","uuid":"adSBq97hhhpFNUnb"}
 {"name":"paste-me.svg","date":"2016-10-24T16:17:49.954Z","url":"https://cdn.hyperdev.com/paste-me.svg","type":"image/svg","size":7242,"imageWidth":276,"imageHeight":276,"thumbnail":"https://cdn.hyperdev.com/paste-me.svg","thumbnailWidth":276,"thumbnailHeight":276,"dominantColor":"rgb(42, 179, 185)","uuid":"adSBq97hhhpFNUnc"}
-{"uuid":"adSBq97hhhpFNUna","deleted":true}
-{"uuid":"adSBq97hhhpFNUnb","deleted":true}
-{"uuid":"adSBq97hhhpFNUnc","deleted":true}

--- a/.glitch-assets
+++ b/.glitch-assets
@@ -1,3 +1,6 @@
 {"name":"drag-in-files.svg","date":"2016-10-22T16:17:49.954Z","url":"https://cdn.hyperdev.com/drag-in-files.svg","type":"image/svg","size":7646,"imageWidth":276,"imageHeight":276,"thumbnail":"https://cdn.hyperdev.com/drag-in-files.svg","thumbnailWidth":276,"thumbnailHeight":276,"dominantColor":"rgb(102, 153, 205)","uuid":"adSBq97hhhpFNUna"}
 {"name":"click-me.svg","date":"2016-10-23T16:17:49.954Z","url":"https://cdn.hyperdev.com/click-me.svg","type":"image/svg","size":7116,"imageWidth":276,"imageHeight":276,"thumbnail":"https://cdn.hyperdev.com/click-me.svg","thumbnailWidth":276,"thumbnailHeight":276,"dominantColor":"rgb(243, 185, 186)","uuid":"adSBq97hhhpFNUnb"}
 {"name":"paste-me.svg","date":"2016-10-24T16:17:49.954Z","url":"https://cdn.hyperdev.com/paste-me.svg","type":"image/svg","size":7242,"imageWidth":276,"imageHeight":276,"thumbnail":"https://cdn.hyperdev.com/paste-me.svg","thumbnailWidth":276,"thumbnailHeight":276,"dominantColor":"rgb(42, 179, 185)","uuid":"adSBq97hhhpFNUnc"}
+{"uuid":"adSBq97hhhpFNUna","deleted":true}
+{"uuid":"adSBq97hhhpFNUnc","deleted":true}
+{"uuid":"adSBq97hhhpFNUnb","deleted":true}

--- a/README.md
+++ b/README.md
@@ -1,31 +1,25 @@
-Welcome to Glitch
-=================
+# hello-sqlite
 
-Click `Show` in the header to see your app live. Updates to your code will instantly deploy and update live.
+A starter with has a database
 
-**Glitch** is the friendly community where you'll build the app of your dreams. Glitch lets you instantly create, remix, edit, and host an app, bot or site, and you can invite collaborators or helpers to simultaneously edit code with you.
-
-Find out more [about Glitch](https://glitch.com/about).
-
-
-Your Project
-------------
+- this app uses sqlite but you can power your apps with [a number of other storage options](https://glitch.com/storage)
+- `sqlite.db` is created and put into the `.data` folder, a hidden directory whose contents aren’t copied when a project is remixed. you can see the contents of `.data` in the console under "Logs"
+- to save to the database, remix this app!
 
 On the front-end,
-- edit `public/client.js`, `public/style.css` and `views/index.html`
+
+- edit `views/index.html`,  `public/style.css`, and `public/client.js`
 - drag in `assets`, like images or music, to add them to your project
 
 On the back-end,
+
 - your app starts at `server.js`
 - add frameworks and packages in `package.json`
 - safely store app secrets in `.env` (nobody can see this but you and people you invite)
 
-This app has a database!
-- this app uses sqlite but you can power your apps with [a number of other storage options](https://glitch.com/storage)
-- `sqlite.db` is created and put into the `.data` folder, a hidden directory whose contents aren’t copied when a project is remixed. you can see the contents of `.data` in the console under "Logs"
+Click `Show` in the header to see your app live. Updates to your code will instantly deploy.
 
 
-Made by [Glitch](https://glitch.com/)
--------------------
+## Made by [Glitch](https://glitch.com/)
 
-\ ゜o゜)ノ
+\ ゜ o ゜)ノ

--- a/public/client.js
+++ b/public/client.js
@@ -3,42 +3,49 @@
 
 console.log("hello world :o");
 
-let dreams = [];
+const dreams = [];
 
 // define variables that reference elements on our page
-const dreamsList = document.getElementById("dreams");
 const dreamsForm = document.forms[0];
 const dreamInput = dreamsForm.elements["dream"];
-
-// a helper function to call when our request for dreams is done
-const getDreamsListener = function() {
-  // parse our response to convert to JSON
-  dreams = JSON.parse(this.responseText);
-
-  // iterate through every dream and add it to our page
-  dreams.forEach(function(row) {
-    appendNewDream(row.dream);
-  });
-};
+const dreamsList = document.getElementById("dreams");
+const dreamsClearBtn = document.getElementById('clear-dreams');
 
 // request the dreams from our app's sqlite database
-const dreamRequest = new XMLHttpRequest();
-dreamRequest.onload = getDreamsListener;
-dreamRequest.open("get", "/getDreams");
-dreamRequest.send();
+fetch("/getDreams", {
+  method: "GET"
+})
+  .then(res => res.json())
+  .then(response => {
+    response.forEach(row => {
+      appendNewDream(row.dream);
+    });
+  });
 
 // a helper function that creates a list item for a given dream
-const appendNewDream = function(dream) {
+const appendNewDream = (dream) => {
   const newListItem = document.createElement("li");
   newListItem.innerHTML = dream;
   dreamsList.appendChild(newListItem);
 };
 
 // listen for the form to be submitted and add a new dream when it is
-dreamsForm.onsubmit = function(event) {
+dreamsForm.onsubmit = (event) => {
   // stop our form submission from refreshing the page
   event.preventDefault();
 
+  // add the dream to the database - NOTE: to actually add to the database, remix this app and uncomment lines 62-74 in server.js
+  const data = { dream: dreamInput.value };
+
+  fetch("/addDream", {
+    method: "POST",
+    body: JSON.stringify(data),
+    headers: { "Content-Type": "application/json" }
+  })
+    .then(res => res.json())
+    .then(response => {
+      console.log(JSON.stringify(response));
+    });
   // get dream value and add it to the list
   dreams.push(dreamInput.value);
   appendNewDream(dreamInput.value);
@@ -47,3 +54,14 @@ dreamsForm.onsubmit = function(event) {
   dreamInput.value = "";
   dreamInput.focus();
 };
+
+const clearDreams = (event) => {
+  fetch("/clearDreams", {
+    method: "GET"
+  })
+  .then(res => res.json())
+  .then(response => {
+    console.log('cleared dreams');
+    dreamsList.innerHTML = '';
+  })
+}

--- a/public/client.js
+++ b/public/client.js
@@ -9,7 +9,6 @@ const dreams = [];
 const dreamsForm = document.forms[0];
 const dreamInput = dreamsForm.elements["dream"];
 const dreamsList = document.getElementById("dreams");
-const dreamsClearBtn = document.getElementById('clear-dreams');
 
 // request the dreams from our app's sqlite database
 fetch("/getDreams", {
@@ -62,6 +61,6 @@ const clearDreams = (event) => {
   .then(res => res.json())
   .then(response => {
     console.log('cleared dreams');
-    dreamsList.innerHTML = '';
-  })
+  });
+  dreamsList.innerHTML = '';
 }

--- a/public/client.js
+++ b/public/client.js
@@ -11,9 +11,7 @@ const dreamInput = dreamsForm.elements["dream"];
 const dreamsList = document.getElementById("dreams");
 
 // request the dreams from our app's sqlite database
-fetch("/getDreams", {
-  method: "GET"
-})
+fetch("/getDreams", {})
   .then(res => res.json())
   .then(response => {
     response.forEach(row => {
@@ -22,18 +20,17 @@ fetch("/getDreams", {
   });
 
 // a helper function that creates a list item for a given dream
-const appendNewDream = (dream) => {
+const appendNewDream = dream => {
   const newListItem = document.createElement("li");
-  newListItem.innerHTML = dream;
+  newListItem.innerText = dream;
   dreamsList.appendChild(newListItem);
 };
 
 // listen for the form to be submitted and add a new dream when it is
-dreamsForm.onsubmit = (event) => {
+dreamsForm.onsubmit = event => {
   // stop our form submission from refreshing the page
   event.preventDefault();
 
-  // add the dream to the database - NOTE: to actually add to the database, remix this app and uncomment lines 62-74 in server.js
   const data = { dream: dreamInput.value };
 
   fetch("/addDream", {
@@ -54,13 +51,11 @@ dreamsForm.onsubmit = (event) => {
   dreamInput.focus();
 };
 
-const clearDreams = (event) => {
-  fetch("/clearDreams", {
-    method: "GET"
-  })
-  .then(res => res.json())
-  .then(response => {
-    console.log('cleared dreams');
-  });
-  dreamsList.innerHTML = '';
-}
+const clearDreams = event => {
+  fetch("/clearDreams", {})
+    .then(res => res.json())
+    .then(response => {
+      console.log("cleared dreams");
+    });
+  dreamsList.innerHTML = "";
+};

--- a/public/client.js
+++ b/public/client.js
@@ -9,6 +9,7 @@ const dreams = [];
 const dreamsForm = document.forms[0];
 const dreamInput = dreamsForm.elements["dream"];
 const dreamsList = document.getElementById("dreams");
+const clearButton = document.querySelector('#clear-dreams');
 
 // request the dreams from our app's sqlite database
 fetch("/getDreams", {})
@@ -51,11 +52,11 @@ dreamsForm.onsubmit = event => {
   dreamInput.focus();
 };
 
-const clearDreams = event => {
+clearButton.addEventListener('click', event => {
   fetch("/clearDreams", {})
     .then(res => res.json())
     .then(response => {
       console.log("cleared dreams");
     });
   dreamsList.innerHTML = "";
-};
+});

--- a/public/style.css
+++ b/public/style.css
@@ -69,3 +69,12 @@ footer {
   padding-top: 25px;
   border-top: 1px solid lightgrey;
 }
+
+.note{
+  width: fit-content;
+  border-radius: 3px;
+  background-color: hotpink;
+  color: white;
+  padding: 2px 10px;
+  font-weight: bold;
+}

--- a/public/style.css
+++ b/public/style.css
@@ -69,12 +69,3 @@ footer {
   padding-top: 25px;
   border-top: 1px solid lightgrey;
 }
-
-.note{
-  width: fit-content;
-  border-radius: 3px;
-  background-color: hotpink;
-  color: white;
-  padding: 2px 10px;
-  font-weight: bold;
-}

--- a/server.js
+++ b/server.js
@@ -24,7 +24,7 @@ const db = new sqlite3.Database(dbFile);
 // if ./.data/sqlite.db does not exist, create it, otherwise print records to console
 db.serialize(() => {
   if (!exists) {
-    db.run("CREATE TABLE Dreams (dream TEXT)");
+    db.run("CREATE TABLE Dreams (id INTEGER PRIMARY KEY AUTOINCREMENT, dream TEXT)");
     console.log("New table Dreams created!");
 
     // insert default dreams
@@ -37,7 +37,7 @@ db.serialize(() => {
     console.log('Database "Dreams" ready to go!');
     db.each("SELECT * from Dreams", (err, row) => {
       if (row) {
-        console.log(`record: ${row}`);
+        console.log(`record: ${row.dream}`);
       }
     });
   }
@@ -59,8 +59,7 @@ app.get("/getDreams", (request, response) => {
 app.post("/addDream", (request, response) => {
   console.log(`add to dreams ${request.body}`);
 
-  // DISALLOW_WRITE is an ENV variable set to TRUE in this template (in .env)
-  // When you remix the app, DISALLOW_WRITE will be reset, and you can add to the database
+  // DISALLOW_WRITE is an ENV variable that gets reset for new projects so you can write to the database
   if (!process.env.DISALLOW_WRITE) {
     db.run(
       `INSERT INTO Dreams (dream) VALUES ("${request.body.dream}")`,
@@ -77,9 +76,8 @@ app.post("/addDream", (request, response) => {
 
 // endpoint to clear dreams from the database
 app.get("/clearDreams", (request, response) => {
-  // DISALLOW_WRITE is an ENV variable set to TRUE in this template (in .env)
-  // When you remix the app, DISALLOW_WRITE will be reset, and you can clear the database
-  if (!process.env.DISALLOW_REWRITE) {
+  // DISALLOW_WRITE is an ENV variable that gets reset for new projects so you can write to the database
+  if (!process.env.DISALLOW_WRITE) {
     db.each(
       "SELECT * from Dreams",
       (err, row) => {

--- a/server.js
+++ b/server.js
@@ -64,7 +64,7 @@ app.post("/addDream", (request, response) => {
   // DISALLOW_WRITE is an ENV variable that gets reset for new projects so you can write to the database
   if (!process.env.DISALLOW_WRITE) {
     const cleansedDream = cleanseString(request.body.dream);
-    db.run(`INSERT INTO Dreams (dream) VALUES (?)`, cleanseString, error => {
+    db.run(`INSERT INTO Dreams (dream) VALUES (?)`, cleansedDream, error => {
       if (error) {
         response.send({ message: "error!" });
       } else {

--- a/server.js
+++ b/server.js
@@ -2,10 +2,12 @@
 // where your node app starts
 
 // init project
-var express = require("express");
-var bodyParser = require("body-parser");
-var app = express();
+const express = require("express");
+const bodyParser = require("body-parser");
+const app = express();
+const fs = require("fs");
 app.use(bodyParser.urlencoded({ extended: true }));
+app.use(bodyParser.json());
 
 // we've started you off with Express,
 // but feel free to use whatever libs or frameworks you'd like through `package.json`.
@@ -14,49 +16,95 @@ app.use(bodyParser.urlencoded({ extended: true }));
 app.use(express.static("public"));
 
 // init sqlite db
-var fs = require("fs");
-var dbFile = "./.data/sqlite.db";
-var exists = fs.existsSync(dbFile);
-var sqlite3 = require("sqlite3").verbose();
-var db = new sqlite3.Database(dbFile);
+const dbFile = "./.data/sqlite.db";
+const exists = fs.existsSync(dbFile);
+const sqlite3 = require("sqlite3").verbose();
+const db = new sqlite3.Database(dbFile);
 
 // if ./.data/sqlite.db does not exist, create it, otherwise print records to console
-db.serialize(function() {
+db.serialize(() => {
   if (!exists) {
     db.run("CREATE TABLE Dreams (dream TEXT)");
     console.log("New table Dreams created!");
 
     // insert default dreams
-    db.serialize(function() {
+    db.serialize(() => {
       db.run(
         'INSERT INTO Dreams (dream) VALUES ("Find and count some sheep"), ("Climb a really tall mountain"), ("Wash the dishes")'
       );
     });
   } else {
     console.log('Database "Dreams" ready to go!');
-    db.each("SELECT * from Dreams", function(err, row) {
+    db.each("SELECT * from Dreams", (err, row) => {
       if (row) {
-        console.log("record:", row);
+        console.log(`record: ${row}`);
       }
     });
   }
 });
 
 // http://expressjs.com/en/starter/basic-routing.html
-app.get("/", function(request, response) {
-  response.sendFile(__dirname + "/views/index.html");
+app.get("/", (request, response) => {
+  response.sendFile(`${__dirname}/views/index.html`);
 });
 
 // endpoint to get all the dreams in the database
-// currently this is the only endpoint, ie. adding dreams won't update the database
-// read the sqlite3 module docs and try to add your own! https://www.npmjs.com/package/sqlite3
-app.get("/getDreams", function(request, response) {
-  db.all("SELECT * from Dreams", function(err, rows) {
+app.get("/getDreams", (request, response) => {
+  db.all("SELECT * from Dreams", (err, rows) => {
     response.send(JSON.stringify(rows));
   });
 });
 
-// listen for requests :)
-var listener = app.listen(process.env.PORT, function() {
-  console.log("Your app is listening on port " + listener.address().port);
+// endpoint to add a dream to the database
+app.post("/addDream", (request, response) => {
+  console.log(`add to dreams ${request.body}`);
+
+  // DISALLOW_WRITE is an ENV variable set to TRUE in this template (in .env)
+  // When you remix the app, DISALLOW_WRITE will be reset, and you can add to the database
+  if (!process.env.DISALLOW_WRITE) {
+    db.run(
+      `INSERT INTO Dreams (dream) VALUES ("${request.body.dream}")`,
+      error => {
+        if (error) {
+          response.send({ message: "error!" });
+        } else {
+          response.send({ message: "success" });
+        }
+      }
+    );
+  }
 });
+
+// endpoint to clear dreams from the database
+app.get("/clearDreams", (request, response) => {
+  // DISALLOW_WRITE is an ENV variable set to TRUE in this template (in .env)
+  // When you remix the app, DISALLOW_WRITE will be reset, and you can clear the database
+  if (!process.env.DISALLOW_REWRITE) {
+    db.each(
+      "SELECT * from Dreams",
+      (err, row) => {
+        console.log("row", row);
+        db.run(`DELETE FROM Dreams WHERE ID=?`, row.id, error => {
+          if (row) {
+            console.log(`deleted row ${row.id}`);
+          }
+        });
+      },
+      err => {
+        if (err) {
+          response.send({ message: "error!" });
+        } else {
+          response.send({ message: "success" });
+        }
+      }
+    );
+  }
+});
+
+// listen for requests :)
+var listener = app.listen(process.env.PORT, () => {
+  console.log(`Your app is listening on port ${listener.address().port}`);
+});
+
+// TODO
+// - add "clear" to delete all items (CRUDDY FOR REALS)

--- a/views/index.html
+++ b/views/index.html
@@ -1,12 +1,6 @@
 <!-- This is a static file -->
 <!-- served from your routes in server.js -->
 
-<!-- You might want to try something fancier: -->
-<!-- html/nunjucks docs: https://mozilla.github.io/nunjucks/ -->
-<!-- pug: https://pugjs.org/ -->
-<!-- haml: http://haml.info/ -->
-<!-- hbs(handlebars): http://handlebarsjs.com/ -->
-
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -40,9 +34,17 @@
         <button type="submit" id="submit-dream">Submit Dream</button>
       </form>
       
+      <p class="note">
+        To save to or delete from the database, <a href="https://glitch.com/edit/#!/remix/longing-eel?utm_source=longing-eel&utm_medium=button&utm_campaign=glitchButton">remix</a> this app
+      </p>
+      
       <section class="dreams">
         <ul id="dreams"></ul>
+        <button id="clear-dreams" onclick="clearDreams()" aria-labelledby="clear-dreams">
+          Clear Dreams
+        </button>
       </section>
+      
     </main>
 
     <footer>

--- a/views/index.html
+++ b/views/index.html
@@ -36,7 +36,7 @@
       
       <section class="dreams">
         <ul id="dreams"></ul>
-        <button id="clear-dreams" onclick="clearDreams()" aria-labelledby="clear-dreams">
+        <button id="clear-dreams" aria-labelledby="clear-dreams">
           Clear Dreams
         </button>
       </section>

--- a/views/index.html
+++ b/views/index.html
@@ -34,10 +34,6 @@
         <button type="submit" id="submit-dream">Submit Dream</button>
       </form>
       
-      <p class="note">
-        To save to or delete from the database, <a href="https://glitch.com/edit/#!/remix/longing-eel?utm_source=longing-eel&utm_medium=button&utm_campaign=glitchButton">remix</a> this app
-      </p>
-      
       <section class="dreams">
         <ul id="dreams"></ul>
         <button id="clear-dreams" onclick="clearDreams()" aria-labelledby="clear-dreams">

--- a/views/index.html
+++ b/views/index.html
@@ -30,13 +30,13 @@
       <p>Tell me your hopes and dreams:</p>
       
       <form>
-        <input name="dream" type="text" maxlength="100" placeholder="Dreams!" aria-labelledby="submit-dream">
+        <input name="dream" aria-label="a new dream" type="text" maxlength="100" placeholder="Dreams!">
         <button type="submit" id="submit-dream">Submit Dream</button>
       </form>
       
       <section class="dreams">
         <ul id="dreams"></ul>
-        <button id="clear-dreams" aria-labelledby="clear-dreams">
+        <button id="clear-dreams">
           Clear Dreams
         </button>
       </section>


### PR DESCRIPTION
Remix: https://longing-eel.glitch.me/

When users remix longing-eel, they are able to submit new dreams (that add the dream to the database) and clear all dreams from the db.

This uses an env variable `DISALLOW_WRITE` which is set to TRUE in the original starter, but reset when the app is remixed.

Additional code changes:
- uses arrow functions
- uses const
- adds an id attribute to the database in order to iteratively remove items from it


To Test:
- Check that you can't add or clear the db on https://longing-eel.glitch.me/
- Remix longing-eel and check that you can add and clear the database

![longing-eel](https://user-images.githubusercontent.com/519336/68241618-fa601680-ffdc-11e9-8589-d56a817ac2fe.gif)


